### PR TITLE
Add in visible side of hull to ship model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Install Bevy Dependencies: https://bevyengine.org/learn/book/getting-started/set
 ```
 cargo run --release
 ```
+
+## Controls
+Move: `W,A,S,D`
+
+Jump: `SPACE`
+
+### Development Controls
+Toggle Navigation Meshes: `M`
+
+Editor: `E`

--- a/src/plugins/atmosphere.rs
+++ b/src/plugins/atmosphere.rs
@@ -26,7 +26,7 @@ fn spawn_atmosphere(mut commands: Commands) {
                 ..default()
             },
             transform: Transform::from_xyz(0.0, 0.0, 0.0)
-                .looking_at(Vec3::new(-0.15, -0.05, 0.25), Vec3::Y),
+                .looking_at(Vec3::new(-0.15, -0.05, -0.35), Vec3::Y),
             cascade_shadow_config,
             ..default()
         },

--- a/src/plugins/ship_builder.rs
+++ b/src/plugins/ship_builder.rs
@@ -35,7 +35,7 @@ fn place_obstacle(
         PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 2.0, 6.0))),
             material: materials.add(Color::ORANGE.into()),
-            transform: Transform::from_xyz(-4.0, SHIP_HEIGHT as f32 + 0.5, 1.0),
+            transform: Transform::from_xyz(-4.0, SHIP_HEIGHT as f32 + (0.5 + 2.0) / 2.0, 1.0),
             ..default()
         },
         RigidBody::Static,

--- a/src/plugins/ship_builder.rs
+++ b/src/plugins/ship_builder.rs
@@ -138,9 +138,22 @@ fn generate_ship(
         NavMeshAffector,
     ));
 
-    // Starboard side of the hull
-
-    // Create port side of hull
+    // Create side of hull
+    commands.spawn((
+        Name::new("Port Wall"),
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box::new(
+                SHIP_LENGTH as f32,
+                SHIP_HEIGHT as f32 + wall_thickness,
+                wall_thickness,
+            ))),
+            material: materials.add(Color::hex("8B4513").unwrap().into()),
+            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            ..default()
+        },
+        RigidBody::Static,
+        Collider::cuboid(0.0, 0.0, 0.0),
+    ));
 
     // Create bow
     commands.spawn((

--- a/src/plugins/ship_builder.rs
+++ b/src/plugins/ship_builder.rs
@@ -144,11 +144,15 @@ fn generate_ship(
         PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Box::new(
                 SHIP_LENGTH as f32,
-                SHIP_HEIGHT as f32 + wall_thickness,
+                SHIP_HEIGHT as f32 - wall_thickness,
                 wall_thickness,
             ))),
             material: materials.add(Color::hex("8B4513").unwrap().into()),
-            transform: Transform::from_xyz(0.0, 0.0, 0.0),
+            transform: Transform::from_xyz(
+                0.0,
+                SHIP_HEIGHT as f32 / 2.0,
+                -((SHIP_WIDTH as f32 - wall_thickness) / 2.0),
+            ),
             ..default()
         },
         RigidBody::Static,

--- a/src/plugins/ship_builder.rs
+++ b/src/plugins/ship_builder.rs
@@ -138,9 +138,9 @@ fn generate_ship(
         NavMeshAffector,
     ));
 
-    // Create side of hull
+    // Create port side of hull
     commands.spawn((
-        Name::new("Port Wall"),
+        Name::new("Port Hull"),
         PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Box::new(
                 SHIP_LENGTH as f32,


### PR DESCRIPTION
The perspective of the game is from a side-view/cross-section of the ship. Before this, the ship only had decks, a bow and a stern. Now it also has the port side of the hull, and the lighting has been adjusted to see in the ship better. Later, we'll add an invisible wall for the starboard side. It will basically just be a collider with no mesh. Something to prevent characters from falling out of the starboard side of the ship.